### PR TITLE
Implement the environment variable USE_CAPI_BMH

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,13 @@ func newApp() *cli.App {
 			Destination: &config.CDIEndpoint,
 			EnvVars:     []string{"CDI_ENDPOINT"},
 		},
+		&cli.BoolFlag{
+			Name:        "use-capi-bmh",
+			Usage:       "Whether to use cluster-api and BareMetalHost or not to get machine uuid",
+			Destination: &config.UseCapiBmh,
+			EnvVars:     []string{"USE_CAPI_BMH"},
+			Value:       false,
+		},
 	}
 
 	app := &cli.App{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	TenantID     string
 	ClusterID    string
 	CDIEndpoint  string
+	UseCapiBmh   bool
 }
 
 type DeviceInfo struct {


### PR DESCRIPTION
This commit implements the followings.
- The environment variable USE_CAPI_BMH to branch the logic of how to get machine uuid depending on its value
- If using cluster-api and BareMetalHost in a cluster, USE_CAPI_BMH is true