### PR TITLE
Add test cases of FindMachineUUIDByProviderID() in kube_utils.go

### DIFF
--- a/pkg/kube_utils/kube_utils.go
+++ b/pkg/kube_utils/kube_utils.go
@@ -322,10 +322,11 @@ func (kc *KubeControllers) FindMachineUUIDByProviderID(providerID normalizedProv
 
 	objs, err := kc.bmhInformer.Informer().GetIndexer().ByIndex(bmhProviderIDIndex, string(providerID))
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	switch n := len(objs); {
 	case n == 0:
+		slog.Warn("not found BareMetalHost for the providerID", "providerID", providerID)
 		return "", nil
 	case n > 1:
 		return "", fmt.Errorf("internal error; expected len==1, got %v", n)

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"cdi_dra/pkg/config"
+	ku "cdi_dra/pkg/kube_utils"
 	"context"
 	"reflect"
 	"testing"
@@ -81,14 +82,16 @@ func createTestDriverResources() map[string]*resourceslice.DriverResources {
 	return ndr
 }
 
-func createTestManager() *CDIManager {
+func createTestManager(useCapiBmh bool) *CDIManager {
 	//kubeObjects := make([]runtime.Object, 0)
 	coreClient := fakekube.NewSimpleClientset()
 	ndr := createTestDriverResources()
 
 	return &CDIManager{
 		coreClient:           coreClient,
+		discoveryClient:      ku.CreateDiscoveryClient(true),
 		namedDriverResources: ndr,
+		useCapiBmh:           useCapiBmh,
 	}
 
 }
@@ -129,8 +132,8 @@ func TestInitDrvierResources(t *testing.T) {
 	}
 }
 
-func TestStartResourceSliceController(t *testing.T) {
-	m := createTestManager()
+func TestCDIManagerStartResourceSliceController(t *testing.T) {
+	m := createTestManager(true)
 
 	testCases := []struct {
 		name                string


### PR DESCRIPTION
This commit implements the followings.
- Add test cases of FindMachineUUIDByProviderID() in kube_utils.go