### PR TITLE
Add test cases of getMachineUUIDs() in manager.go

### DIFF
--- a/pkg/kube_utils/test_helper.go
+++ b/pkg/kube_utils/test_helper.go
@@ -34,12 +34,18 @@ func MustCreateKubeControllers(t testing.TB, testConfig *TestConfig) (*KubeContr
 	}
 	for i := range testConfig.Nodes {
 		objects = append(objects, testConfig.Nodes[i])
-
 	}
 
 	machineObjects := make([]runtime.Object, 0)
-	for i := range testConfig.BMHs {
-		machineObjects = append(machineObjects, testConfig.BMHs[i])
+	for _, machine := range testConfig.Machines {
+		if machine != nil {
+			machineObjects = append(machineObjects, machine)
+		}
+	}
+	for _, bmh := range testConfig.BMHs {
+		if bmh != nil {
+			machineObjects = append(machineObjects, bmh)
+		}
 	}
 	kubeclient := fakekube.NewSimpleClientset(objects...)
 	dynamicclient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(


### PR DESCRIPTION
This commit implements the followings.
- Add test cases of getMachineUUIDs() in manager.go
- Add test cases of ListProviderIDs() and FindNodeNameByProviderID() in kube_utils.go